### PR TITLE
Feat: Support :var Input to org babel code blocks

### DIFF
--- a/ob-dart.el
+++ b/ob-dart.el
@@ -83,9 +83,13 @@ Args:
         (cdr (assoc :rowname-names params)) (cdr (assoc :rownames params)))))))
 
 (defun ob-dart-get-var-declarations (vars)
-  "Generate Dart variable declarations for VARS from the given VAR list."
+  "Generate Dart variable declarations from the given VARS list."
   (mapconcat (lambda (var)
-               (format "var %s = %s;" (car var) (cdr var)))
+               (format "var %s = %s;"
+                       (car var)
+                       (if (listp (cdr var))
+                           (mapconcat #'identity (cdr var) ", ")
+                         (cdr var))))
              vars "\n"))
 
 (defun ob-dart-evaluate (session body &optional result-type result-params)


### PR DESCRIPTION
for testing i used the following blocks

#+NAME: ob-dart-variables-result-output
#+BEGIN_SRC dart :var projectname="dart" :var input="why" :results output
print("Project Name: $projectname");
print("Input: $input");
#+END_SRC

#+NAME: ob-dart-variables-result-value
#+BEGIN_SRC dart :var projectname="dart" :var input="why" :results value
return "Project Name: $projectname, Input: $input";
#+END_SRC


#+NAME: dart-body-main
#+begin_src dart :results output
/// Complete Dart code snippet can be wrapped.
main(List args) {
  var listMax = [10,20,30].reduce(max);
  print ('WE HAVE MAIN');
  print ('In output mode, all printed lines show in result');
  print ('List max printed = ' + listMax.toString());
  return ('Results: value!! List from MAIN');
  }
main([]);
#+end_src

#+RESULTS: dart-body-main
: WE HAVE MAIN
: In output mode, all printed lines show in result
: List max printed = 30

#+NAME: ob-dart-function
#+begin_src dart :var number=4
   square(x) {
           return x * x;
    }
    return square(number);
#+end_src

#+RESULTS: ob-dart-function
: 16

#+NAME: ob-dart-print-var-input
#+begin_src dart :var input="why" :results output
  // Access the variable using the `vars` object
  var message = "$input";

  // Use the input variable
  print(message);
#+end_src
